### PR TITLE
Fix GitHub workflow publishing to Docker Hub

### DIFF
--- a/.github/workflows/publish-to-dockerhub.yml
+++ b/.github/workflows/publish-to-dockerhub.yml
@@ -1,8 +1,7 @@
-name: Docker Image CI
+name: Publish to Docker Hub
 
 on:
   push:
-    branches: [ master ]
     tags:
       - 'v-[0-9]+-[0-9]+-[0-9]+.[0-9]+'
 
@@ -48,6 +47,7 @@ jobs:
           file: ./Dockerfile
           labels: ${{ steps.meta.outputs.labels }}
           no-cache: true
+          push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
 
       - name: Image digest


### PR DESCRIPTION
It amends the pull request #1 to address the following issues:

* Image was built for every push to the branch `master`, even commit push, whereas we want build to be triggered only for tag push.
* Image was built but not pushed to Docker Hub registry, because I accidentally removed the `push` flag from `picard-website`’s example.

It is submitted as a pull request to check that it doesn’t trigger a new build.