### PR TITLE
Support multiple ListenAddress via comma-separated env var

### DIFF
--- a/sshd.service
+++ b/sshd.service
@@ -5,7 +5,13 @@ set -e
 SSHD_LISTEN_ADDRESS=${SSHD_LISTEN_ADDRESS:-0.0.0.0}
 SSHD_PORT=${SSHD_PORT:-22}
 
+listen_args=""
+IFS=','
+for addr in $SSHD_LISTEN_ADDRESS; do
+    listen_args="$listen_args -o ListenAddress=$addr"
+done
+
 exec /usr/sbin/sshd \
     -D \
-    -o "ListenAddress=$SSHD_LISTEN_ADDRESS" \
+    $listen_args \
     -o "Port=$SSHD_PORT"


### PR DESCRIPTION
Split `SSHD_LISTEN_ADDRESS` on commas to generate multiple `-o ListenAddress=<addr>` arguments, allowing sshd to listen on several addresses.

Backward compatible: a single address (default `0.0.0.0`) works identically to before.

Examples:
```bash
SSHD_LISTEN_ADDRESS=0.0.0.0                  # single (unchanged)
SSHD_LISTEN_ADDRESS=0.0.0.0,192.168.1.10     # multiple IPv4
SSHD_LISTEN_ADDRESS=0.0.0.0,::1              # mixed IPv4+IPv6
```